### PR TITLE
feat(tailwind): set up primary color and font-family in tailwind css configuration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,3 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  overflow: hidden;
+}
+
+@layer utilities {}
+
+@layer components{}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+	weight: ["300", "400", "500", "600", "700"],
+	display: "swap",
+	subsets: ["latin"],
+	variable: "--inter",
+});
 
 export const metadata: Metadata = {
   title: "simple site",
@@ -16,7 +21,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.variable}>{children}</body>
     </html>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,21 @@ const config: Config = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+				inter: ["var(--inter)"],
+			},
+      colors: {
+        primary: {
+          50: "#F3F5F7",
+					100: "#E8ECEF",
+					500: "#6C7275",
+					600: "#343839",
+					700: "#232627",
+					900: "#000000",
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
This pr adds configuration settings for the primary color and font-family in the Tailwind CSS configuration file. Now, the Tailwind styles will use the specified primary color and font-family throughout the project.